### PR TITLE
Fix harmony crash on AddRespawnPointsPatch

### DIFF
--- a/Patches.cs
+++ b/Patches.cs
@@ -52,7 +52,7 @@ namespace RespawnMenuImprovements
             }
         }
 
-        [HarmonyPatch(typeof(MyGuiScreenMedicals))]
+        [HarmonyPatch]
         public class AddRespawnPointsPatch
         {
             public static MethodBase TargetMethod()


### PR DESCRIPTION
You cannot specify a class in the HarmonyPatch when using targetmethod to get the method needed to be patched. This seems to be a recent issue with harmony.